### PR TITLE
tweak the Ls interface

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.11: QmXLwxifxwfc2bAwq6rdjbYqAsGzWsDE9RM5TWMGtykyj6
+0.1.12: QmY1veddRDFZZBUFp2Mysw7mf2sSmbx1ZGH5v11tTMCYN5

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
   "license": "",
   "name": "interface-go-ipfs-core",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.11"
+  "version": "0.1.12"
 }
 

--- a/tests/unixfs.go
+++ b/tests/unixfs.go
@@ -786,9 +786,6 @@ func (tp *provider) TestLs(t *testing.T) {
 		t.Errorf("expected symlink target to be /foo/bar, got %s", entry.Target)
 	}
 
-	if int(entry.Size) != len(entry.Target) {
-		t.Errorf("expected size = %d, got %d", len(entry.Target), entry.Size)
-	}
 	if l, ok := <-entries; ok {
 		t.Errorf("didn't expect a second link")
 		if l.Err != nil {

--- a/tests/unixfs.go
+++ b/tests/unixfs.go
@@ -782,12 +782,12 @@ func (tp *provider) TestLs(t *testing.T) {
 	if entry.Name != "name-of-symlink" {
 		t.Errorf("expected name = name-of-symlink, got %s", entry.Name)
 	}
-	if entry.Target.String() != "/foo/bar" {
+	if entry.Target != "/foo/bar" {
 		t.Errorf("expected symlink target to be /foo/bar, got %s", entry.Target)
 	}
 
-	if int(entry.Size) != len(entry.Target.String()) {
-		t.Errorf("expected size = %d, got %d", len(entry.Target.String()), entry.Size)
+	if int(entry.Size) != len(entry.Target) {
+		t.Errorf("expected size = %d, got %d", len(entry.Target), entry.Size)
 	}
 	if l, ok := <-entries; ok {
 		t.Errorf("didn't expect a second link")

--- a/tests/unixfs.go
+++ b/tests/unixfs.go
@@ -750,26 +750,25 @@ func (tp *provider) TestLs(t *testing.T) {
 		t.Error(err)
 	}
 
-	links, err := api.Unixfs().Ls(ctx, p)
+	entries, err := api.Unixfs().Ls(ctx, p)
 	if err != nil {
 		t.Error(err)
 	}
 
-	linkRes := <-links
-	if linkRes.Err != nil {
-		t.Fatal(linkRes.Err)
+	entry := <-entries
+	if entry.Err != nil {
+		t.Fatal(entry.Err)
 	}
-	link := linkRes.Link
-	if linkRes.Size != 15 {
-		t.Fatalf("expected size = 15, got %d", link.Size)
+	if entry.Size != 15 {
+		t.Fatalf("expected size = 15, got %d", entry.Size)
 	}
-	if link.Name != "name-of-file" {
-		t.Fatalf("expected name = name-of-file, got %s", link.Name)
+	if entry.Name != "name-of-file" {
+		t.Fatalf("expected name = name-of-file, got %s", entry.Name)
 	}
-	if link.Cid.String() != "QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr" {
-		t.Fatalf("expected cid = QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr, got %s", link.Cid)
+	if entry.Cid.String() != "QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr" {
+		t.Fatalf("expected cid = QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr, got %s", entry.Cid)
 	}
-	if l, ok := <-links; ok {
+	if l, ok := <-entries; ok {
 		t.Errorf("didn't expect a second link")
 		if l.Err != nil {
 			t.Error(l.Err)

--- a/unixfs.go
+++ b/unixfs.go
@@ -30,6 +30,21 @@ const (
 	TSymlink
 )
 
+func (t FileType) String() string {
+	switch t {
+	case TUnknown:
+		return "unknown"
+	case TFile:
+		return "file"
+	case TDirectory:
+		return "directory"
+	case TSymlink:
+		return "symlink"
+	default:
+		return "<unknown file type>"
+	}
+}
+
 // DirEntry is a directory entry returned by `Ls`.
 type DirEntry struct {
 	Name string

--- a/unixfs.go
+++ b/unixfs.go
@@ -53,7 +53,7 @@ type DirEntry struct {
 	// Only filled when asked to resolve the directory entry.
 	Size   uint64   // The size of the file in bytes (or the size of the symlink).
 	Type   FileType // The type of the file.
-	Target Path     // The symlink target (if a symlink).
+	Target string   // The symlink target (if a symlink).
 
 	Err error
 }


### PR DESCRIPTION
1. Avoid `ipld.Link`. This is a protodag specific thing that will go away in future IPLD versions.
2. Avoid exposing the underlying file types. The user shouldn't care if they're dealing with a hamt, etc.
3. Add a field for a symlink's target.
4. Rename LsLink to DirEntry to better this type's role.