### PR TITLE
fix a bunch of small test "bugs"

### DIFF
--- a/tests/block.go
+++ b/tests/block.go
@@ -52,7 +52,7 @@ func (tp *provider) TestBlockPutFormat(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	res, err := api.Block().Put(ctx, strings.NewReader(`Hello`), opt.Block.Format("cbor"))
@@ -70,7 +70,7 @@ func (tp *provider) TestBlockPutHash(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	res, err := api.Block().Put(ctx, strings.NewReader(`Hello`), opt.Block.Hash(mh.KECCAK_512, -1))
@@ -88,7 +88,7 @@ func (tp *provider) TestBlockGet(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	res, err := api.Block().Put(ctx, strings.NewReader(`Hello`), opt.Block.Hash(mh.KECCAK_512, -1))
@@ -98,12 +98,12 @@ func (tp *provider) TestBlockGet(t *testing.T) {
 
 	r, err := api.Block().Get(ctx, res.Path())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	d, err := ioutil.ReadAll(r)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if string(d) != "Hello" {
@@ -112,7 +112,7 @@ func (tp *provider) TestBlockGet(t *testing.T) {
 
 	p, err := coreiface.ParsePath("/ipfs/" + res.Path().Cid().String())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	rp, err := api.ResolvePath(ctx, p)
@@ -129,7 +129,7 @@ func (tp *provider) TestBlockRm(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	res, err := api.Block().Put(ctx, strings.NewReader(`Hello`))
@@ -139,12 +139,12 @@ func (tp *provider) TestBlockRm(t *testing.T) {
 
 	r, err := api.Block().Get(ctx, res.Path())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	d, err := ioutil.ReadAll(r)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if string(d) != "Hello" {
@@ -153,7 +153,7 @@ func (tp *provider) TestBlockRm(t *testing.T) {
 
 	err = api.Block().Rm(ctx, res.Path())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Block().Get(ctx, res.Path())
@@ -174,7 +174,7 @@ func (tp *provider) TestBlockRm(t *testing.T) {
 
 	err = api.Block().Rm(ctx, res.Path(), opt.Block.Force(true))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -183,7 +183,7 @@ func (tp *provider) TestBlockStat(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	res, err := api.Block().Put(ctx, strings.NewReader(`Hello`))
@@ -193,7 +193,7 @@ func (tp *provider) TestBlockStat(t *testing.T) {
 
 	stat, err := api.Block().Stat(ctx, res.Path())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if stat.Path().String() != res.Path().String() {
@@ -210,7 +210,7 @@ func (tp *provider) TestBlockPin(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Block().Put(ctx, strings.NewReader(`Hello`))

--- a/tests/dag.go
+++ b/tests/dag.go
@@ -44,12 +44,12 @@ func (tp *provider) TestPut(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`"Hello"`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Dag().Add(ctx, nd)
@@ -67,12 +67,12 @@ func (tp *provider) TestPutWithHash(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`"Hello"`), mh.ID, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Dag().Add(ctx, nd)
@@ -90,12 +90,12 @@ func (tp *provider) TestDagPath(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	snd, err := ipldcbor.FromJSON(strings.NewReader(`"foo"`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Dag().Add(ctx, snd)
@@ -105,7 +105,7 @@ func (tp *provider) TestDagPath(t *testing.T) {
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`{"lnk": {"/": "`+snd.Cid().String()+`"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Dag().Add(ctx, nd)
@@ -115,17 +115,17 @@ func (tp *provider) TestDagPath(t *testing.T) {
 
 	p, err := coreiface.ParsePath(path.Join(nd.Cid().String(), "lnk"))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	rp, err := api.ResolvePath(ctx, p)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	ndd, err := api.Dag().Get(ctx, rp.Cid())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if ndd.Cid().String() != snd.Cid().String() {
@@ -138,12 +138,12 @@ func (tp *provider) TestTree(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`{"a": 123, "b": "foo", "c": {"d": 321, "e": 111}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Dag().Add(ctx, nd)
@@ -153,7 +153,7 @@ func (tp *provider) TestTree(t *testing.T) {
 
 	res, err := api.Dag().Get(ctx, nd.Cid())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	lst := res.Tree("", -1)
@@ -173,12 +173,12 @@ func (tp *provider) TestBatch(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`"Hello"`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if nd.Cid().String() != "zdpuAqckYF3ToF3gcJNxPZXmnmGuXd3gxHCXhq81HGxBejEvv" {
@@ -187,15 +187,15 @@ func (tp *provider) TestBatch(t *testing.T) {
 
 	_, err = api.Dag().Get(ctx, nd.Cid())
 	if err == nil || !strings.Contains(err.Error(), "not found") {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := api.Dag().AddMany(ctx, []ipld.Node{nd}); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Dag().Get(ctx, nd.Cid())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }

--- a/tests/key.go
+++ b/tests/key.go
@@ -121,7 +121,7 @@ func (tp *provider) TestGenerate(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	k, err := api.Key().Generate(ctx, "foo")
@@ -144,7 +144,7 @@ func (tp *provider) TestGenerateSize(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	k, err := api.Key().Generate(ctx, "foo", opt.Key.Size(1024))
@@ -169,7 +169,7 @@ func (tp *provider) TestGenerateType(t *testing.T) {
 
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	k, err := api.Key().Generate(ctx, "bar", opt.Key.Type(opt.Ed25519Key))
@@ -193,7 +193,7 @@ func (tp *provider) TestGenerateExisting(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -226,7 +226,7 @@ func (tp *provider) TestList(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -272,7 +272,7 @@ func (tp *provider) TestRename(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -301,7 +301,7 @@ func (tp *provider) TestRenameToSelf(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -325,7 +325,7 @@ func (tp *provider) TestRenameToSelfForce(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -349,7 +349,7 @@ func (tp *provider) TestRenameOverwriteNoForce(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -379,7 +379,7 @@ func (tp *provider) TestRenameOverwrite(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	kfoo, err := api.Key().Generate(ctx, "foo")
@@ -418,7 +418,7 @@ func (tp *provider) TestRenameSameNameNoForce(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -447,7 +447,7 @@ func (tp *provider) TestRenameSameName(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Key().Generate(ctx, "foo")
@@ -476,7 +476,7 @@ func (tp *provider) TestRemove(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	k, err := api.Key().Generate(ctx, "foo")

--- a/tests/object.go
+++ b/tests/object.go
@@ -296,7 +296,7 @@ func (tp *provider) TestObjectAddLinkCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p3, err := api.Object().AddLink(ctx, p2, "abc/d", p2)
+	_, err = api.Object().AddLink(ctx, p2, "abc/d", p2)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -304,7 +304,7 @@ func (tp *provider) TestObjectAddLinkCreate(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 
-	p3, err = api.Object().AddLink(ctx, p2, "abc/d", p2, opt.Object.Create(true))
+	p3, err := api.Object().AddLink(ctx, p2, "abc/d", p2, opt.Object.Create(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,6 +384,9 @@ func (tp *provider) TestObjectAddData(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if string(data) != "foobar" {
 		t.Error("unexpected data")
@@ -414,6 +417,9 @@ func (tp *provider) TestObjectSetData(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if string(data) != "bar" {
 		t.Error("unexpected data")

--- a/tests/path.go
+++ b/tests/path.go
@@ -68,7 +68,7 @@ func (tp *provider) TestPathRemainder(t *testing.T) {
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`{"foo": {"bar": "baz"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := api.Dag().Add(ctx, nd); err != nil {
@@ -77,7 +77,7 @@ func (tp *provider) TestPathRemainder(t *testing.T) {
 
 	p1, err := coreiface.ParsePath(nd.String() + "/foo/bar")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	rp1, err := api.ResolvePath(ctx, p1)
@@ -104,7 +104,7 @@ func (tp *provider) TestEmptyPathRemainder(t *testing.T) {
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`{"foo": {"bar": "baz"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := api.Dag().Add(ctx, nd); err != nil {
@@ -113,7 +113,7 @@ func (tp *provider) TestEmptyPathRemainder(t *testing.T) {
 
 	p1, err := coreiface.ParsePath(nd.Cid().String())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	rp1, err := api.ResolvePath(ctx, p1)
@@ -140,7 +140,7 @@ func (tp *provider) TestInvalidPathRemainder(t *testing.T) {
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`{"foo": {"bar": "baz"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := api.Dag().Add(ctx, nd); err != nil {
@@ -149,7 +149,7 @@ func (tp *provider) TestInvalidPathRemainder(t *testing.T) {
 
 	p1, err := coreiface.ParsePath("/ipld/" + nd.Cid().String() + "/bar/baz")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.ResolvePath(ctx, p1)
@@ -181,7 +181,7 @@ func (tp *provider) TestPathRoot(t *testing.T) {
 
 	nd, err := ipldcbor.FromJSON(strings.NewReader(`{"foo": {"/": "`+blk.Path().Cid().String()+`"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := api.Dag().Add(ctx, nd); err != nil {
@@ -190,7 +190,7 @@ func (tp *provider) TestPathRoot(t *testing.T) {
 
 	p1, err := coreiface.ParsePath("/ipld/" + nd.Cid().String() + "/foo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	rp, err := api.ResolvePath(ctx, p1)
@@ -210,7 +210,7 @@ func (tp *provider) TestPathRoot(t *testing.T) {
 func (tp *provider) TestPathJoin(t *testing.T) {
 	p1, err := coreiface.ParsePath("/ipfs/QmYNmQKp6SuaVrpgWRsPTgCQCnpxUYGq76YEKBXuj2N4H6/bar/baz")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if coreiface.Join(p1, "foo").String() != "/ipfs/QmYNmQKp6SuaVrpgWRsPTgCQCnpxUYGq76YEKBXuj2N4H6/bar/baz/foo" {

--- a/tests/pin.go
+++ b/tests/pin.go
@@ -31,17 +31,17 @@ func (tp *provider) TestPinAdd(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	p, err := api.Unixfs().Add(ctx, strFile("foo")())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Pin().Add(ctx, p)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -50,17 +50,17 @@ func (tp *provider) TestPinSimple(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	p, err := api.Unixfs().Add(ctx, strFile("foo")())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Pin().Add(ctx, p)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	list, err := api.Pin().Ls(ctx)
@@ -100,27 +100,27 @@ func (tp *provider) TestPinRecursive(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	p0, err := api.Unixfs().Add(ctx, strFile("foo")())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	p1, err := api.Unixfs().Add(ctx, strFile("bar")())
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd2, err := ipldcbor.FromJSON(strings.NewReader(`{"lnk": {"/": "`+p0.Cid().String()+`"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd3, err := ipldcbor.FromJSON(strings.NewReader(`{"lnk": {"/": "`+p1.Cid().String()+`"}}`), math.MaxUint64, -1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := api.Dag().AddMany(ctx, []ipld.Node{nd2, nd3}); err != nil {
@@ -129,12 +129,12 @@ func (tp *provider) TestPinRecursive(t *testing.T) {
 
 	err = api.Pin().Add(ctx, iface.IpldPath(nd2.Cid()))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = api.Pin().Add(ctx, iface.IpldPath(nd3.Cid()), opt.Pin.Recursive(false))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	list, err := api.Pin().Ls(ctx)

--- a/tests/pubsub.go
+++ b/tests/pubsub.go
@@ -40,7 +40,9 @@ func (tp *provider) TestBasicPubSub(t *testing.T) {
 		for {
 			err := apis[1].PubSub().Publish(ctx, "testch", []byte("hello world"))
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				cancel()
+				return
 			}
 			select {
 			case <-tick:

--- a/tests/pubsub.go
+++ b/tests/pubsub.go
@@ -35,7 +35,8 @@ func (tp *provider) TestBasicPubSub(t *testing.T) {
 	}
 
 	go func() {
-		tick := time.Tick(100 * time.Millisecond)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
 
 		for {
 			err := apis[1].PubSub().Publish(ctx, "testch", []byte("hello world"))
@@ -45,7 +46,7 @@ func (tp *provider) TestBasicPubSub(t *testing.T) {
 				return
 			}
 			select {
-			case <-tick:
+			case <-ticker.C:
 			case <-ctx.Done():
 				return
 			}

--- a/tests/unixfs.go
+++ b/tests/unixfs.go
@@ -423,11 +423,13 @@ func (tp *provider) TestAdd(t *testing.T) {
 					for evt := range eventOut {
 						event, ok := evt.(*coreiface.AddEvent)
 						if !ok {
-							t.Fatal("unexpected event type")
+							t.Error("unexpected event type")
+							continue
 						}
 
 						if len(expected) < 1 {
-							t.Fatal("got more events than expected")
+							t.Error("got more events than expected")
+							continue
 						}
 
 						if expected[0].Size != event.Size {
@@ -453,7 +455,7 @@ func (tp *provider) TestAdd(t *testing.T) {
 					}
 
 					if len(expected) > 0 {
-						t.Fatalf("%d event(s) didn't arrive", len(expected))
+						t.Errorf("%d event(s) didn't arrive", len(expected))
 					}
 				}()
 			}

--- a/tests/unixfs.go
+++ b/tests/unixfs.go
@@ -98,7 +98,7 @@ func (tp *provider) TestAdd(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	p := func(h string) coreiface.ResolvedPath {
@@ -566,15 +566,18 @@ func (tp *provider) TestAddPinned(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Unixfs().Add(ctx, strFile(helloStr)(), options.Unixfs.Pin(true))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	pins, err := api.Pin().Ls(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(pins) != 1 {
 		t.Fatalf("expected 1 pin, got %d", len(pins))
 	}
@@ -589,12 +592,12 @@ func (tp *provider) TestAddHashOnly(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	p, err := api.Unixfs().Add(ctx, strFile(helloStr)(), options.Unixfs.HashOnly(true))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if p.String() != hello {
@@ -648,18 +651,18 @@ func (tp *provider) TestGetDir(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	edir := unixfs.EmptyDirNode()
 	err = api.Dag().Add(ctx, edir)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	p := coreiface.IpfsPath(edir.Cid())
 
 	emptyDir, err := api.Object().New(ctx, options.Object.Type("unixfs-dir"))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if p.String() != coreiface.IpfsPath(emptyDir.Cid()).String() {
@@ -668,7 +671,7 @@ func (tp *provider) TestGetDir(t *testing.T) {
 
 	r, err := api.Unixfs().Get(ctx, coreiface.IpfsPath(emptyDir.Cid()))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if _, ok := r.(files.Directory); !ok {
@@ -681,13 +684,13 @@ func (tp *provider) TestGetNonUnixfs(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd := new(mdag.ProtoNode)
 	err = api.Dag().Add(ctx, nd)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Unixfs().Get(ctx, coreiface.IpfsPath(nd.Cid()))
@@ -761,7 +764,7 @@ func (tp *provider) TestEntriesExpired(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	r := strings.NewReader("content-of-file")
@@ -769,14 +772,14 @@ func (tp *provider) TestEntriesExpired(t *testing.T) {
 		"name-of-file": files.NewReaderFile(r),
 	}))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	ctx, cancel = context.WithCancel(ctx)
 
 	nd, err := api.Unixfs().Get(ctx, p)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	cancel()
 
@@ -803,22 +806,22 @@ func (tp *provider) TestLsEmptyDir(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = api.Unixfs().Add(ctx, files.NewSliceDirectory([]files.DirEntry{}))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	emptyDir, err := api.Object().New(ctx, options.Object.Type("unixfs-dir"))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	links, err := api.Unixfs().Ls(ctx, coreiface.IpfsPath(emptyDir.Cid()))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if len(links) != 0 {
@@ -832,7 +835,7 @@ func (tp *provider) TestLsNonUnixfs(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	nd, err := cbor.WrapObject(map[string]interface{}{"foo": "bar"}, math.MaxUint64, -1)
@@ -842,12 +845,12 @@ func (tp *provider) TestLsNonUnixfs(t *testing.T) {
 
 	err = api.Dag().Add(ctx, nd)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	links, err := api.Unixfs().Ls(ctx, coreiface.IpfsPath(nd.Cid()))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if len(links) != 0 {
@@ -890,7 +893,7 @@ func (tp *provider) TestAddCloses(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	n4 := &closeTestF{files.NewBytesFile([]byte("foo")), false, t}
@@ -907,7 +910,7 @@ func (tp *provider) TestAddCloses(t *testing.T) {
 
 	_, err = api.Unixfs().Add(ctx, d0)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	d0.Close() // Adder doesn't close top-level file
@@ -930,7 +933,7 @@ func (tp *provider) TestGetSeek(t *testing.T) {
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	dataSize := int64(100000)


### PR DESCRIPTION
* Avoid Fatal in goroutines.
* Use fatal when we can't continue the test.
* Make sure to check all results.
* Avoid leaking timers.