### PR TITLE
test: fix put with hash test

### DIFF
--- a/tests/dag.go
+++ b/tests/dag.go
@@ -71,7 +71,7 @@ func (tp *TestSuite) TestPutWithHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nd, err := ipldcbor.FromJSON(strings.NewReader(`"Hello"`), mh.ID, -1)
+	nd, err := ipldcbor.FromJSON(strings.NewReader(`"Hello"`), mh.SHA3_256, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func (tp *TestSuite) TestPutWithHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if nd.Cid().String() != "bafyqabtfjbswy3dp" {
+	if nd.Cid().String() != "bafyrmifu7haikttpqqgc5ewvmp76z3z4ebp7h2ph4memw7dq4nt6btmxny" {
 		t.Errorf("got wrong cid: %s", nd.Cid().String())
 	}
 }


### PR DESCRIPTION
We just changed ID/"id" to IDENTITY/"identity" to match the multicodec table and
avoid confusion with peer IDs, CIDs, etc.

Unfortunately, this breaks the `--hash=id` flag. Luckily, I'm pretty sure
nobody's actually using this. As putting a block with an identity hash is
useless. If they are users, we can go about adding in backwards compatibility
hacks later.