### PR TITLE
add Pin.IsPinned(..)

### DIFF
--- a/options/pin.go
+++ b/options/pin.go
@@ -2,46 +2,48 @@ package options
 
 import "fmt"
 
+// PinAddSettings represent the settings for PinAPI.Add
 type PinAddSettings struct {
 	Recursive bool
 }
 
-type TypeSettings struct {
-	Type string
-}
-
+// PinLsSettings represent the settings for PinAPI.Ls
 type PinLsSettings struct {
 	Type string
 }
 
+// PinIsPinnedSettings represent the settings for PinAPI.IsPinned
 type PinIsPinnedSettings struct {
 	WithType string
 }
 
-// PinRmSettings represents the settings of pin rm command
+// PinRmSettings represents the settings for PinAPI.Rm
 type PinRmSettings struct {
 	Recursive bool
 }
 
+// PinUpdateSettings represent the settings for PinAPI.Update
 type PinUpdateSettings struct {
 	Unpin bool
 }
 
-// PinAddOption pin add option func
+// PinAddOption is the signature of an option for PinAPI.Add
 type PinAddOption func(*PinAddSettings) error
 
-// PinLsOption pin ls option func
+// PinLsOption is the signature of an option for PinAPI.Ls
 type PinLsOption func(*PinLsSettings) error
 
-// PinIsPinnedOption pin isPinned option func
+// PinIsPinnedOption is the signature of an option for PinAPI.IsPinned
 type PinIsPinnedOption func(*PinIsPinnedSettings) error
 
-// PinRmOption pin rm option func
+// PinRmOption is the signature of an option for PinAPI.Rm
 type PinRmOption func(*PinRmSettings) error
 
-// PinUpdateOption pin update option func
+// PinUpdateOption is the signature of an option for PinAPI.Update
 type PinUpdateOption func(*PinUpdateSettings) error
 
+// PinAddOptions compile a series of PinAddOption into a ready to use
+// PinAddSettings and set the default values.
 func PinAddOptions(opts ...PinAddOption) (*PinAddSettings, error) {
 	options := &PinAddSettings{
 		Recursive: true,
@@ -57,6 +59,8 @@ func PinAddOptions(opts ...PinAddOption) (*PinAddSettings, error) {
 	return options, nil
 }
 
+// PinLsOptions compile a series of PinLsOption into a ready to use
+// PinLsSettings and set the default values.
 func PinLsOptions(opts ...PinLsOption) (*PinLsSettings, error) {
 	options := &PinLsSettings{
 		Type: "all",
@@ -72,6 +76,8 @@ func PinLsOptions(opts ...PinLsOption) (*PinLsSettings, error) {
 	return options, nil
 }
 
+// PinIsPinnedOptions compile a series of PinIsPinnedOption into a ready to use
+// PinIsPinnedSettings and set the default values.
 func PinIsPinnedOptions(opts ...PinIsPinnedOption) (*PinIsPinnedSettings, error) {
 	options := &PinIsPinnedSettings{
 		WithType: "all",
@@ -87,7 +93,8 @@ func PinIsPinnedOptions(opts ...PinIsPinnedOption) (*PinIsPinnedSettings, error)
 	return options, nil
 }
 
-// PinRmOptions pin rm options
+// PinRmOptions compile a series of PinRmOption into a ready to use
+// PinRmSettings and set the default values.
 func PinRmOptions(opts ...PinRmOption) (*PinRmSettings, error) {
 	options := &PinRmSettings{
 		Recursive: true,
@@ -102,6 +109,8 @@ func PinRmOptions(opts ...PinRmOption) (*PinRmSettings, error) {
 	return options, nil
 }
 
+// PinUpdateOptions compile a series of PinUpdateOption into a ready to use
+// PinUpdateSettings and set the default values.
 func PinUpdateOptions(opts ...PinUpdateOption) (*PinUpdateSettings, error) {
 	options := &PinUpdateSettings{
 		Unpin: true,
@@ -122,6 +131,7 @@ type pinOpts struct {
 	IsPinned pinIsPinnedOpts
 }
 
+// Pin provide an access to all the options for the Pin API.
 var Pin pinOpts
 
 type pinLsOpts struct{}

--- a/pin.go
+++ b/pin.go
@@ -46,6 +46,10 @@ type PinAPI interface {
 	// Ls returns list of pinned objects on this node
 	Ls(context.Context, ...options.PinLsOption) (<-chan Pin, error)
 
+	// IsPinned returns whether or not the given cid is pinned
+	// and an explanation of why its pinned
+	IsPinned(context.Context, path.Path, ...options.PinIsPinnedOption) (string, bool, error)
+
 	// Rm removes pin for object specified by the path
 	Rm(context.Context, path.Path, ...options.PinRmOption) error
 

--- a/tests/pin.go
+++ b/tests/pin.go
@@ -28,6 +28,7 @@ func (tp *TestSuite) TestPin(t *testing.T) {
 	t.Run("TestPinRecursive", tp.TestPinRecursive)
 	t.Run("TestPinLsIndirect", tp.TestPinLsIndirect)
 	t.Run("TestPinLsPrecedence", tp.TestPinLsPrecedence)
+	t.Run("TestPinIsPinned", tp.TestPinIsPinned)
 }
 
 func (tp *TestSuite) TestPinAdd(t *testing.T) {
@@ -83,6 +84,8 @@ func (tp *TestSuite) TestPinSimple(t *testing.T) {
 	if list[0].Type() != "recursive" {
 		t.Error("unexpected pin type")
 	}
+
+	assertIsPinned(t, ctx, api, p, "recursive")
 
 	err = api.Pin().Rm(ctx, p)
 	if err != nil {
@@ -150,7 +153,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Errorf("unexpected pin list len: %d", len(list))
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Type.Direct()))
+	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Direct()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +166,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Errorf("unexpected path, %s != %s", list[0].Path().String(), path.IpfsPath(nd3.Cid()).String())
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Type.Recursive()))
+	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Recursive()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +179,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Errorf("unexpected path, %s != %s", list[0].Path().String(), path.IpldPath(nd2.Cid()).String())
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Type.Indirect()))
+	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Indirect()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,6 +363,39 @@ func (tp *TestSuite) TestPinLsPrecedenceRecursiveDirect(t *testing.T) {
 	assertPinTypes(t, ctx, api, []cidContainer{grandparent, parent}, []cidContainer{}, []cidContainer{leaf})
 }
 
+func (tp *TestSuite) TestPinIsPinned(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	api, err := tp.makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leaf, parent, grandparent := getThreeChainedNodes(t, ctx, api, "foofoo")
+
+	assertNotPinned(t, ctx, api, path.IpldPath(grandparent.Cid()))
+	assertNotPinned(t, ctx, api, path.IpldPath(parent.Cid()))
+	assertNotPinned(t, ctx, api, path.IpldPath(leaf.Cid()))
+
+	err = api.Pin().Add(ctx, path.IpldPath(parent.Cid()), opt.Pin.Recursive(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertNotPinned(t, ctx, api, path.IpldPath(grandparent.Cid()))
+	assertIsPinned(t, ctx, api, path.IpldPath(parent.Cid()), "recursive")
+	assertIsPinned(t, ctx, api, path.IpldPath(leaf.Cid()), "indirect")
+
+	err = api.Pin().Add(ctx, path.IpldPath(grandparent.Cid()), opt.Pin.Recursive(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertIsPinned(t, ctx, api, path.IpldPath(grandparent.Cid()), "direct")
+	assertIsPinned(t, ctx, api, path.IpldPath(parent.Cid()), "recursive")
+	assertIsPinned(t, ctx, api, path.IpldPath(leaf.Cid()), "indirect")
+}
+
 type cidContainer interface {
 	Cid() cid.Cid
 }
@@ -390,21 +426,21 @@ func getThreeChainedNodes(t *testing.T, ctx context.Context, api iface.CoreAPI, 
 func assertPinTypes(t *testing.T, ctx context.Context, api iface.CoreAPI, recusive, direct, indirect []cidContainer) {
 	assertPinLsAllConsistency(t, ctx, api)
 
-	list, err := accPins(api.Pin().Ls(ctx, opt.Pin.Type.Recursive()))
+	list, err := accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Recursive()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertPinCids(t, list, recusive...)
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Type.Direct()))
+	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Direct()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertPinCids(t, list, direct...)
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Type.Indirect()))
+	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Indirect()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,9 +502,9 @@ func assertPinLsAllConsistency(t *testing.T, ctx context.Context, api iface.Core
 
 	all, recursive, direct, indirect := cid.NewSet(), cid.NewSet(), cid.NewSet(), cid.NewSet()
 	typeMap := map[string]*pinTypeProps{
-		"recursive": {recursive, opt.Pin.Type.Recursive()},
-		"direct":    {direct, opt.Pin.Type.Direct()},
-		"indirect":  {indirect, opt.Pin.Type.Indirect()},
+		"recursive": {recursive, opt.Pin.Ls.Recursive()},
+		"direct":    {direct, opt.Pin.Ls.Direct()},
+		"indirect":  {indirect, opt.Pin.Ls.Indirect()},
 	}
 
 	for _, p := range allPins {
@@ -503,6 +539,47 @@ func assertPinLsAllConsistency(t *testing.T, ctx context.Context, api iface.Core
 				t.Fatalf("%s expected to be in pin ls all as type %s", c.String(), typeStr)
 			}
 		}
+	}
+}
+
+func assertIsPinned(t *testing.T, ctx context.Context, api iface.CoreAPI, p path.Path, typeStr string) {
+	t.Helper()
+	withType, err := opt.Pin.IsPinned.Type(typeStr)
+	if err != nil {
+		panic("unhandled pin type")
+	}
+
+	whyPinned, pinned, err := api.Pin().IsPinned(ctx, p, withType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !pinned {
+		t.Fatalf("%s expected to be pinned with type %s", p, typeStr)
+	}
+
+	switch typeStr {
+	case "recursive", "direct":
+		if typeStr != whyPinned {
+			t.Fatalf("reason for pinning expected to be %s for %s, got %s", typeStr, p, whyPinned)
+		}
+	case "indirect":
+		if whyPinned == "" {
+			t.Fatalf("expected to have a pin reason for %s", p)
+		}
+	}
+}
+
+func assertNotPinned(t *testing.T, ctx context.Context, api iface.CoreAPI, p path.Path) {
+	t.Helper()
+
+	_, pinned, err := api.Pin().IsPinned(ctx, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pinned {
+		t.Fatalf("%s expected to not be pinned", p)
 	}
 }
 

--- a/tests/pin.go
+++ b/tests/pin.go
@@ -546,7 +546,7 @@ func assertIsPinned(t *testing.T, ctx context.Context, api iface.CoreAPI, p path
 	t.Helper()
 	withType, err := opt.Pin.IsPinned.Type(typeStr)
 	if err != nil {
-		panic("unhandled pin type")
+		t.Fatal("unhandled pin type")
 	}
 
 	whyPinned, pinned, err := api.Pin().IsPinned(ctx, p, withType)


### PR DESCRIPTION
This PR add the following function to the Pin API:

```go
// IsPinned returns whether or not the given cid is pinned
// and an explanation of why its pinned
IsPinned(context.Context, path.Path, ...options.PinIsPinnedOption) (string, bool, error)
```

This is needed to ultimately implement `ipfs pin ls <cid>`.

To do so, it was also needed to migrate the `PinLsOptions` into their own namespace.

Note: to avoid conflicts, this PR is chained with #49 so the diff here will include both until #49 is merged.