### PR TITLE
Add method to import keys into keychain

### DIFF
--- a/key.go
+++ b/key.go
@@ -27,6 +27,9 @@ type KeyAPI interface {
 	// name and returns a base58 encoded multihash of it's public key
 	Generate(ctx context.Context, name string, opts ...options.KeyGenerateOption) (Key, error)
 
+	// Imports a key and stores in the keystore under the specified name
+	Import(ctx context.Context, name string, key []byte) (Key, error)
+
 	// Rename renames oldName key to newName. Returns the key and whether another
 	// key was overwritten, or an error
 	Rename(ctx context.Context, oldName string, newName string, opts ...options.KeyRenameOption) (Key, bool, error)


### PR DESCRIPTION
Per https://github.com/ipfs/go-ipfs/issues/4240 I thought I'd move toward the first steps here.

**Exported key storage format**
* This can be an opaque format.  The goal is backing up one's identity and using it on multiple workstations/devices, neither of which usecases need to know the internal format.
* `PrivKey` already has marshal/unmarshal.  I don't know if these include a version number/are future proof/are frozen but PrivKey is a good target since everything else can be derived from it.

**Import**
Since the serialized format is opaque Import takes a blob.

**Export**
Users might want to install ipfs, generate a key, and import it on another (remote?) machine without setting up ipfs locally.  That said, I think there are two options here:
1. Add additional parameters to Generate (flag to generate only without storing), plus the private key as a blob would need to be included in `Key` or a new return type defined.  I'm not sure what backward compatibility guarantees are here... I've seen some other libraries do things like `Generate2` `Generate3` to avoid breaking the interface.
2. Alternatively it might make sense to ignore `Generate` and crypto or something can provide a standalone function for creating keys from KeyGenerateOption, which can then be added with `Import`.  In that case only `Import` is needed here I think.