### PR TITLE
Update error message for go-ipld-prime path resolution

### DIFF
--- a/tests/path.go
+++ b/tests/path.go
@@ -2,10 +2,11 @@ package tests
 
 import (
 	"context"
-	"github.com/ipfs/interface-go-ipfs-core/path"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/ipfs/interface-go-ipfs-core/path"
 
 	"github.com/ipfs/interface-go-ipfs-core/options"
 
@@ -138,7 +139,9 @@ func (tp *TestSuite) TestInvalidPathRemainder(t *testing.T) {
 	}
 
 	_, err = api.ResolvePath(ctx, path.New("/ipld/"+nd.Cid().String()+"/bar/baz"))
-	if err == nil || !strings.Contains(err.Error(), "no such link found") {
+	if err == nil ||
+		(!strings.Contains(err.Error(), "no such link found") && // pre-ipld-prime error msg
+			!strings.Contains(err.Error(), "no link named \"bar\" under bafyreidddp34f6fnymowkvohkxvk4dk5zjt7z35tmhpctzw6cfpcna4xvq")) { // go-ipld-prime error msg
 		t.Fatalf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
Arising out of the go-ipld-prime in go-ipfs work. Failing @ https://github.com/ipfs/go-ipfs/pull/7995

@hannahhoward's updates to go-path now use go-ipld-prime selector traversal to do path resolution and we get more verbose error messages.

In this change I'm allowing both the old and the new style error messages. I'm unsure if that's appropriate or not but it seems to me that coordinating this getting up through go-ipfs-http-client to go-ipfs is going to be awkward enough that being a little more lax about exact message is fine and can be resolved at some future date. I'm also making an assumption that we shouldn't be trying to emulate the old style error message when the new one is more informative.

While I'm in here, I'm not sure this test is doing what it _should_ be testing. We have a block that looks like `{"foo": {"bar": "baz"}}` with CID `X`, then we're requesting a path through that block: `X/bar/baz` where there is no `bar` at the top level. This test is called "InvalidPathRemainder" but it's not even getting started. Is it testing what it _should_ be testing? Was it supposed to be testing `X/foo/bar/baz` perhaps? :shrug: maybe we could clarify what this test is supposed to be doing while in here.