### PR TITLE
refactor: BlockPutSettings.CidPrefix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/multiformats/go-multiaddr v0.3.3
 	github.com/multiformats/go-multibase v0.0.3
+	github.com/multiformats/go-multicodec v0.3.0
 	github.com/multiformats/go-multihash v0.0.15
 )
 

--- a/go.sum
+++ b/go.sum
@@ -713,6 +713,8 @@ github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.3.0 h1:tstDwfIjiHbnIjeM5Lp+pMrSeN+LCMsEwOrkPmWm03A=
+github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/options/block.go
+++ b/options/block.go
@@ -3,10 +3,13 @@ package options
 import (
 	"fmt"
 	cid "github.com/ipfs/go-cid"
+	mc "github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
 )
 
 type BlockPutSettings struct {
+	StoreCodec string
+	// FIXME: Rename to Format (and possibly mark as deprecated).
 	Codec    string
 	MhType   uint64
 	MhLength int
@@ -22,10 +25,11 @@ type BlockRmOption func(*BlockRmSettings) error
 
 func BlockPutOptions(opts ...BlockPutOption) (*BlockPutSettings, cid.Prefix, error) {
 	options := &BlockPutSettings{
-		Codec:    "",
-		MhType:   mh.SHA2_256,
-		MhLength: -1,
-		Pin:      false,
+		Codec:      "",
+		StoreCodec: "",
+		MhType:     mh.SHA2_256,
+		MhLength:   -1,
+		Pin:        false,
 	}
 
 	for _, opt := range opts {
@@ -35,33 +39,49 @@ func BlockPutOptions(opts ...BlockPutOption) (*BlockPutSettings, cid.Prefix, err
 		}
 	}
 
+	if options.Codec != "" && options.StoreCodec != "" {
+		return nil, cid.Prefix{}, fmt.Errorf("incompatible format (%s) and store-codec options set (%s)",
+			options.Codec, options.StoreCodec)
+	}
+
+	if options.Codec == "" && options.StoreCodec == "" {
+		// FIXME(BLOCKING): Do we keep the old default v0 here?
+		options.Codec = "v0"
+		// FIXME(BLOCKING): Review how to handle "protobuf". For now we simplify the code only with "v0".
+	}
+
 	var pref cid.Prefix
 	pref.Version = 1
 
-	if options.Codec == "" {
-		if options.MhType != mh.SHA2_256 || (options.MhLength != -1 && options.MhLength != 32) {
-			options.Codec = "protobuf"
-		} else {
-			options.Codec = "v0"
+	// Old format option.
+	if options.Codec != "" {
+		if options.Codec == "v0" {
+			if options.MhType != mh.SHA2_256 || (options.MhLength != -1 && options.MhLength != 32) {
+				return nil, cid.Prefix{}, fmt.Errorf("only sha2-255-32 is allowed with CIDv0")
+			}
+			pref.Version = 0
 		}
-	}
 
-	if options.Codec == "v0" && options.MhType == mh.SHA2_256 {
-		pref.Version = 0
-	}
-
-	formatval, ok := cid.Codecs[options.Codec]
-	if !ok {
-		return nil, cid.Prefix{}, fmt.Errorf("unrecognized format: %s", options.Codec)
-	}
-
-	if options.Codec == "v0" {
-		if options.MhType != mh.SHA2_256 || (options.MhLength != -1 && options.MhLength != 32) {
-			return nil, cid.Prefix{}, fmt.Errorf("only sha2-255-32 is allowed with CIDv0")
+		// FIXME(BLOCKING): Do we actually want to consult the CID codecs table
+		//  even with the old --format options? Or do we always want to check
+		//  the multicodec one?
+		cidCodec, ok := cid.Codecs[options.Codec]
+		if !ok {
+			return nil, cid.Prefix{}, fmt.Errorf("unrecognized format: %s", options.Codec)
 		}
+		pref.Codec = cidCodec
+	} else {
+		// New store-codec options. We handle it as it's done for `ipfs dag put`.
+		var storeCodec mc.Code
+		if err := storeCodec.Set(options.StoreCodec); err != nil {
+			return nil, cid.Prefix{}, err
+		}
+		pref.Codec = uint64(storeCodec)
 	}
 
-	pref.Codec = formatval
+	// FIXME: The entire codec manipulation/validation needs to be encapsulated
+	//  outside this funtion to clearly demark that it is the only option we are
+	//  overwriting here.
 
 	pref.MhType = options.MhType
 	pref.MhLength = options.MhLength
@@ -92,6 +112,15 @@ var Block blockOpts
 func (blockOpts) Format(codec string) BlockPutOption {
 	return func(settings *BlockPutSettings) error {
 		settings.Codec = codec
+		return nil
+	}
+}
+
+// StoreCodec is an option for Block.Put which specifies the multicodec to use to
+// serialize the object. It replaces the old Format now with CIDv1 as the default.
+func (blockOpts) StoreCodec(storeCodec string) BlockPutOption {
+	return func(settings *BlockPutSettings) error {
+		settings.StoreCodec = storeCodec
 		return nil
 	}
 }

--- a/options/block.go
+++ b/options/block.go
@@ -2,18 +2,15 @@ package options
 
 import (
 	"fmt"
+
 	cid "github.com/ipfs/go-cid"
 	mc "github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
 )
 
 type BlockPutSettings struct {
-	StoreCodec string
-	// FIXME: Rename to Format (and possibly mark as deprecated).
-	Codec    string
-	MhType   uint64
-	MhLength int
-	Pin      bool
+	CidPrefix cid.Prefix
+	Pin       bool
 }
 
 type BlockRmSettings struct {
@@ -23,70 +20,29 @@ type BlockRmSettings struct {
 type BlockPutOption func(*BlockPutSettings) error
 type BlockRmOption func(*BlockRmSettings) error
 
-func BlockPutOptions(opts ...BlockPutOption) (*BlockPutSettings, cid.Prefix, error) {
+func BlockPutOptions(opts ...BlockPutOption) (*BlockPutSettings, error) {
+	var cidPrefix cid.Prefix
+
+	// Baseline is CIDv1 raw sha2-255-32 (can be tweaked later via opts)
+	cidPrefix.Version = 1
+	cidPrefix.Codec = uint64(mc.Raw)
+	cidPrefix.MhType = mh.SHA2_256
+	cidPrefix.MhLength = -1 // -1 means len is to be calculated during mh.Sum()
+
 	options := &BlockPutSettings{
-		Codec:      "",
-		StoreCodec: "",
-		MhType:     mh.SHA2_256,
-		MhLength:   -1,
-		Pin:        false,
+		CidPrefix: cidPrefix,
+		Pin:       false,
 	}
 
+	// Apply any overrides
 	for _, opt := range opts {
 		err := opt(options)
 		if err != nil {
-			return nil, cid.Prefix{}, err
+			return nil, err
 		}
 	}
 
-	if options.Codec != "" && options.StoreCodec != "" {
-		return nil, cid.Prefix{}, fmt.Errorf("incompatible format (%s) and store-codec options set (%s)",
-			options.Codec, options.StoreCodec)
-	}
-
-	if options.Codec == "" && options.StoreCodec == "" {
-		// FIXME(BLOCKING): Do we keep the old default v0 here?
-		options.Codec = "v0"
-		// FIXME(BLOCKING): Review how to handle "protobuf". For now we simplify the code only with "v0".
-	}
-
-	var pref cid.Prefix
-	pref.Version = 1
-
-	// Old format option.
-	if options.Codec != "" {
-		if options.Codec == "v0" {
-			if options.MhType != mh.SHA2_256 || (options.MhLength != -1 && options.MhLength != 32) {
-				return nil, cid.Prefix{}, fmt.Errorf("only sha2-255-32 is allowed with CIDv0")
-			}
-			pref.Version = 0
-		}
-
-		// FIXME(BLOCKING): Do we actually want to consult the CID codecs table
-		//  even with the old --format options? Or do we always want to check
-		//  the multicodec one?
-		cidCodec, ok := cid.Codecs[options.Codec]
-		if !ok {
-			return nil, cid.Prefix{}, fmt.Errorf("unrecognized format: %s", options.Codec)
-		}
-		pref.Codec = cidCodec
-	} else {
-		// New store-codec options. We handle it as it's done for `ipfs dag put`.
-		var storeCodec mc.Code
-		if err := storeCodec.Set(options.StoreCodec); err != nil {
-			return nil, cid.Prefix{}, err
-		}
-		pref.Codec = uint64(storeCodec)
-	}
-
-	// FIXME: The entire codec manipulation/validation needs to be encapsulated
-	//  outside this funtion to clearly demark that it is the only option we are
-	//  overwriting here.
-
-	pref.MhType = options.MhType
-	pref.MhLength = options.MhLength
-
-	return options, pref, nil
+	return options, nil
 }
 
 func BlockRmOptions(opts ...BlockRmOption) (*BlockRmSettings, error) {
@@ -107,22 +63,75 @@ type blockOpts struct{}
 
 var Block blockOpts
 
-// Format is an option for Block.Put which specifies the multicodec to use to
-// serialize the object. Default is "v0"
-func (blockOpts) Format(codec string) BlockPutOption {
+// CidCodec is the modern option for Block.Put which specifies the multicodec to use
+// in the CID returned by the Block.Put operation.
+// It uses correct codes from go-multicodec and replaces the old Format now with CIDv1 as the default.
+func (blockOpts) CidCodec(codecName string) BlockPutOption {
 	return func(settings *BlockPutSettings) error {
-		settings.Codec = codec
+		if codecName == "" {
+			return nil
+		}
+		code, err := codeFromName(codecName)
+		if err != nil {
+			return err
+		}
+		settings.CidPrefix.Codec = uint64(code)
 		return nil
 	}
 }
 
-// StoreCodec is an option for Block.Put which specifies the multicodec to use to
-// serialize the object. It replaces the old Format now with CIDv1 as the default.
-func (blockOpts) StoreCodec(storeCodec string) BlockPutOption {
+// Map string to code from go-multicodec
+func codeFromName(codecName string) (mc.Code, error) {
+	var cidCodec mc.Code
+	err := cidCodec.Set(codecName)
+	return cidCodec, err
+}
+
+// Format is a legacy option for Block.Put which specifies the multicodec to
+// use to serialize the object.
+// Provided for backward-compatibility only. Use CidCodec instead.
+func (blockOpts) Format(format string) BlockPutOption {
 	return func(settings *BlockPutSettings) error {
-		settings.StoreCodec = storeCodec
+		if format == "" {
+			return nil
+		}
+		// Opt-in CIDv0 support for backward-compatibility
+		if format == "v0" {
+			settings.CidPrefix.Version = 0
+		}
+
+		// Fixup a legacy (invalid) names for dag-pb (0x70)
+		if format == "v0" || format == "protobuf" {
+			format = "dag-pb"
+		}
+
+		// Fixup invalid name for dag-cbor (0x71)
+		if format == "cbor" {
+			format = "dag-cbor"
+		}
+
+		// Set code based on name passed as "format"
+		code, err := codeFromName(format)
+		if err != nil {
+			return err
+		}
+		settings.CidPrefix.Codec = uint64(code)
+
+		// If CIDv0, ensure all parameters are compatible
+		// (in theory go-cid would validate this anyway, but we want to provide better errors)
+		pref := settings.CidPrefix
+		if pref.Version == 0 {
+			if pref.Codec != uint64(mc.DagPb) {
+				return fmt.Errorf("only dag-pb is allowed with CIDv0")
+			}
+			if pref.MhType != mh.SHA2_256 || (pref.MhLength != -1 && pref.MhLength != 32) {
+				return fmt.Errorf("only sha2-255-32 is allowed with CIDv0")
+			}
+		}
+
 		return nil
 	}
+
 }
 
 // Hash is an option for Block.Put which specifies the multihash settings to use
@@ -130,8 +139,8 @@ func (blockOpts) StoreCodec(storeCodec string) BlockPutOption {
 // If mhLen is set to -1, default length for the hash will be used
 func (blockOpts) Hash(mhType uint64, mhLen int) BlockPutOption {
 	return func(settings *BlockPutSettings) error {
-		settings.MhType = mhType
-		settings.MhLength = mhLen
+		settings.CidPrefix.MhType = mhType
+		settings.CidPrefix.MhLength = mhLen
 		return nil
 	}
 }

--- a/tests/block.go
+++ b/tests/block.go
@@ -92,7 +92,7 @@ func (tp *TestSuite) TestBlockPutStoreCodec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := api.Block().Put(ctx, cborBlock(), opt.Block.StoreCodec("cbor"))
+	res, err := api.Block().Put(ctx, cborBlock(), opt.Block.StoreCodec("dag-cbor"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/block.go
+++ b/tests/block.go
@@ -19,6 +19,7 @@ import (
 var (
 	pbCidV0  = "QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN"                                                                 // dag-pb
 	pbCid    = "bafybeiffndsajwhk3lwjewwdxqntmjm4b5wxaaanokonsggenkbw6slwk4"                                                    // dag-pb
+	rawCid   = "bafkreiffndsajwhk3lwjewwdxqntmjm4b5wxaaanokonsggenkbw6slwk4"                                                    // raw bytes
 	cborCid  = "bafyreicnga62zhxnmnlt6ymq5hcbsg7gdhqdu6z4ehu3wpjhvqnflfy6nm"                                                    // dag-cbor
 	cborKCid = "bafyr2qgsohbwdlk7ajmmbb4lhoytmest4wdbe5xnexfvtxeatuyqqmwv3fgxp3pmhpc27gwey2cct56gloqefoqwcf3yqiqzsaqb7p4jefhcw" // dag-cbor keccak-512
 )
@@ -41,7 +42,8 @@ func (tp *TestSuite) TestBlock(t *testing.T) {
 		return nil
 	})
 
-	t.Run("TestBlockPut", tp.TestBlockPut)
+	t.Run("TestBlockPut (get raw CIDv1)", tp.TestBlockPut)
+	t.Run("TestBlockPutCidCodec: dag-pb", tp.TestBlockPutCidCodecDagPb)
 	t.Run("TestBlockPutCidCodec: dag-cbor", tp.TestBlockPutCidCodecDagCbor)
 	t.Run("TestBlockPutFormat (legacy): cbor → dag-cbor", tp.TestBlockPutFormatDagCbor)
 	t.Run("TestBlockPutFormat (legacy): protobuf → dag-pb", tp.TestBlockPutFormatDagPb)
@@ -53,6 +55,7 @@ func (tp *TestSuite) TestBlock(t *testing.T) {
 	t.Run("TestBlockPin", tp.TestBlockPin)
 }
 
+// when no opts are passed, produced CID has 'raw' codec
 func (tp *TestSuite) TestBlockPut(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -66,7 +69,7 @@ func (tp *TestSuite) TestBlockPut(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if res.Path().Cid().String() != pbCid {
+	if res.Path().Cid().String() != rawCid {
 		t.Errorf("got wrong cid: %s", res.Path().Cid().String())
 	}
 }

--- a/tests/block.go
+++ b/tests/block.go
@@ -40,6 +40,7 @@ func (tp *TestSuite) TestBlock(t *testing.T) {
 
 	t.Run("TestBlockPut", tp.TestBlockPut)
 	t.Run("TestBlockPutFormat", tp.TestBlockPutFormat)
+	t.Run("TestBlockPutStoreCodec", tp.TestBlockPutStoreCodec)
 	t.Run("TestBlockPutHash", tp.TestBlockPutHash)
 	t.Run("TestBlockGet", tp.TestBlockGet)
 	t.Run("TestBlockRm", tp.TestBlockRm)
@@ -74,6 +75,24 @@ func (tp *TestSuite) TestBlockPutFormat(t *testing.T) {
 	}
 
 	res, err := api.Block().Put(ctx, cborBlock(), opt.Block.Format("cbor"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Path().Cid().String() != cborCid {
+		t.Errorf("got wrong cid: %s", res.Path().Cid().String())
+	}
+}
+
+func (tp *TestSuite) TestBlockPutStoreCodec(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	api, err := tp.makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := api.Block().Put(ctx, cborBlock(), opt.Block.StoreCodec("cbor"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/block.go
+++ b/tests/block.go
@@ -17,15 +17,18 @@ import (
 )
 
 var (
-	pbCid    = "QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN"
-	cborCid  = "bafyreicnga62zhxnmnlt6ymq5hcbsg7gdhqdu6z4ehu3wpjhvqnflfy6nm"
-	cborKCid = "bafyr2qgsohbwdlk7ajmmbb4lhoytmest4wdbe5xnexfvtxeatuyqqmwv3fgxp3pmhpc27gwey2cct56gloqefoqwcf3yqiqzsaqb7p4jefhcw"
+	pbCidV0  = "QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN"                                                                 // dag-pb
+	pbCid    = "bafybeiffndsajwhk3lwjewwdxqntmjm4b5wxaaanokonsggenkbw6slwk4"                                                    // dag-pb
+	cborCid  = "bafyreicnga62zhxnmnlt6ymq5hcbsg7gdhqdu6z4ehu3wpjhvqnflfy6nm"                                                    // dag-cbor
+	cborKCid = "bafyr2qgsohbwdlk7ajmmbb4lhoytmest4wdbe5xnexfvtxeatuyqqmwv3fgxp3pmhpc27gwey2cct56gloqefoqwcf3yqiqzsaqb7p4jefhcw" // dag-cbor keccak-512
 )
 
+// dag-pb
 func pbBlock() io.Reader {
 	return bytes.NewReader([]byte{10, 12, 8, 2, 18, 6, 104, 101, 108, 108, 111, 10, 24, 6})
 }
 
+// dag-cbor
 func cborBlock() io.Reader {
 	return bytes.NewReader([]byte{101, 72, 101, 108, 108, 111})
 }
@@ -39,8 +42,10 @@ func (tp *TestSuite) TestBlock(t *testing.T) {
 	})
 
 	t.Run("TestBlockPut", tp.TestBlockPut)
-	t.Run("TestBlockPutFormat", tp.TestBlockPutFormat)
-	t.Run("TestBlockPutStoreCodec", tp.TestBlockPutStoreCodec)
+	t.Run("TestBlockPutCidCodec: dag-cbor", tp.TestBlockPutCidCodecDagCbor)
+	t.Run("TestBlockPutFormat (legacy): cbor → dag-cbor", tp.TestBlockPutFormatDagCbor)
+	t.Run("TestBlockPutFormat (legacy): protobuf → dag-pb", tp.TestBlockPutFormatDagPb)
+	t.Run("TestBlockPutFormat (legacy): v0 → CIDv0", tp.TestBlockPutFormatV0)
 	t.Run("TestBlockPutHash", tp.TestBlockPutHash)
 	t.Run("TestBlockGet", tp.TestBlockGet)
 	t.Run("TestBlockRm", tp.TestBlockRm)
@@ -66,7 +71,9 @@ func (tp *TestSuite) TestBlockPut(t *testing.T) {
 	}
 }
 
-func (tp *TestSuite) TestBlockPutFormat(t *testing.T) {
+// Format is deprecated, it used invalid codec names.
+// Confirm 'cbor' gets fixed to 'dag-cbor'
+func (tp *TestSuite) TestBlockPutFormatDagCbor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
@@ -84,7 +91,9 @@ func (tp *TestSuite) TestBlockPutFormat(t *testing.T) {
 	}
 }
 
-func (tp *TestSuite) TestBlockPutStoreCodec(t *testing.T) {
+// Format is deprecated, it used invalid codec names.
+// Confirm 'protobuf' got fixed to 'dag-pb'
+func (tp *TestSuite) TestBlockPutFormatDagPb(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	api, err := tp.makeAPI(ctx)
@@ -92,12 +101,68 @@ func (tp *TestSuite) TestBlockPutStoreCodec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := api.Block().Put(ctx, cborBlock(), opt.Block.StoreCodec("dag-cbor"))
+	res, err := api.Block().Put(ctx, pbBlock(), opt.Block.Format("protobuf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Path().Cid().String() != pbCid {
+		t.Errorf("got wrong cid: %s", res.Path().Cid().String())
+	}
+}
+
+// Format is deprecated, it used invalid codec names.
+// Confirm fake codec 'v0' got fixed to CIDv0 (with implicit dag-pb codec)
+func (tp *TestSuite) TestBlockPutFormatV0(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	api, err := tp.makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := api.Block().Put(ctx, pbBlock(), opt.Block.Format("v0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Path().Cid().String() != pbCidV0 {
+		t.Errorf("got wrong cid: %s", res.Path().Cid().String())
+	}
+}
+
+func (tp *TestSuite) TestBlockPutCidCodecDagCbor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	api, err := tp.makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := api.Block().Put(ctx, cborBlock(), opt.Block.CidCodec("dag-cbor"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if res.Path().Cid().String() != cborCid {
+		t.Errorf("got wrong cid: %s", res.Path().Cid().String())
+	}
+}
+
+func (tp *TestSuite) TestBlockPutCidCodecDagPb(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	api, err := tp.makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := api.Block().Put(ctx, pbBlock(), opt.Block.CidCodec("dag-pb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Path().Cid().String() != pbCid {
 		t.Errorf("got wrong cid: %s", res.Path().Cid().String())
 	}
 }
@@ -114,7 +179,7 @@ func (tp *TestSuite) TestBlockPutHash(t *testing.T) {
 		ctx,
 		cborBlock(),
 		opt.Block.Hash(mh.KECCAK_512, -1),
-		opt.Block.Format("cbor"),
+		opt.Block.CidCodec("dag-cbor"),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.2"
+  "version": "v0.7.0"
 }


### PR DESCRIPTION
Cleanup related to https://github.com/ipfs/go-ipfs/issues/8471, required by https://github.com/ipfs/go-ipfs/pull/8568

## TLDR

### CIDv1 returned by default 

Part of https://github.com/ipfs/ipfs/issues/337.
The `raw `codec  is used by default, unless custom one is set in `BlockPutOptions`  via `CidCodec` func:

```go
result, err := api.Block().Put(req.Context, file, options.Block.CidCodec(cidCodec))
```

### CID prefix is now part of BlockPutSettings

```diff
caopts "github.com/ipfs/interface-go-ipfs-core/options"

- settings, pref, err := caopts.BlockPutOptions(opts...)
+ settings, err := caopts.BlockPutOptions(opts...)
...
-	calculatedCid, err := pref.Sum(data)
+	calculatedCid, err := settings.CidPrefix.Sum(data)
```


## BREAKING CHANGES

  - implicit `BlockPutSettings` now produces CIDv1 with `raw` codec by default now
    - `CidCodec` makes `block put` return CID with alternative codec 
       -  this impacts only the returned CID, it does  not trigger any validation or data transformation
       - codec names are validated against tables from https://github.com/multiformats/go-multicodec
    - `Format` is deprecated. It used incorrect codec names and should be avoided for new deployments. Use it only if you need the old, invalid behavior, namely things described in https://github.com/ipfs/go-ipfs/pull/8568:
      - `ipfs block put --format=v0` will produce CIDv0 (implicit dag-pb)
      - `ipfs block put --format=cbor` will produce CIDv1 with dag-cbor (!)
      - `ipfs block put --format=protobuf` will produce CIDv1 with dag-pb (!)

Closes #51 (we default to `raw` and not `dag-pb` anymore)
