### PR TITLE
add NamePublishOption AllowWhileMounted

### DIFF
--- a/options/name.go
+++ b/options/name.go
@@ -16,7 +16,8 @@ type NamePublishSettings struct {
 
 	TTL *time.Duration
 
-	AllowOffline bool
+	AllowOffline      bool
+	AllowWhileMounted bool
 }
 
 type NameResolveSettings struct {
@@ -33,7 +34,8 @@ func NamePublishOptions(opts ...NamePublishOption) (*NamePublishSettings, error)
 		ValidTime: DefaultNameValidTime,
 		Key:       "self",
 
-		AllowOffline: false,
+		AllowOffline:      false,
+		AllowWhileMounted: false,
 	}
 
 	for _, opt := range opts {
@@ -91,6 +93,15 @@ func (nameOpts) Key(key string) NamePublishOption {
 func (nameOpts) AllowOffline(allow bool) NamePublishOption {
 	return func(settings *NamePublishSettings) error {
 		settings.AllowOffline = allow
+		return nil
+	}
+}
+
+// AllowWhileMounted is an option for Name.Publish which specifies whether to
+// allow publishing while the IPNS filesystem is mounted. Default value is false
+func (nameOpts) AllowWhileMounted(allow bool) NamePublishOption {
+	return func(settings *NamePublishSettings) error {
+		settings.AllowWhileMounted = allow
 		return nil
 	}
 }


### PR DESCRIPTION
We need to bypass the publishing lock-out within the IPNS Fuse implementation itself, to fix github/ipfs/kubo/#2168
Anyway, perhaps the "solution" to ipfs/kubo#964 needs to become configurable.