### PR TITLE
feat: add RoutingAPI to CoreAPI

### DIFF
--- a/coreapi.go
+++ b/coreapi.go
@@ -44,6 +44,9 @@ type CoreAPI interface {
 	// PubSub returns an implementation of PubSub API
 	PubSub() PubSubAPI
 
+	// Routing returns an implementation of Routing API
+	Routing() RoutingAPI
+
 	// ResolvePath resolves the path using Unixfs resolver
 	ResolvePath(context.Context, path.Path) (path.Resolved, error)
 

--- a/routing.go
+++ b/routing.go
@@ -1,0 +1,14 @@
+package iface
+
+import (
+	"context"
+)
+
+// RoutingAPI specifies the interface to the routing layer.
+type RoutingAPI interface {
+	// Get retrieves the best value for a given key
+	Get(context.Context, string) ([]byte, error)
+
+	// Put sets a value for a given key
+	Put(ctx context.Context, key string, value []byte) error
+}


### PR DESCRIPTION
- [x] #94 **must be merged first**.

The Routing API allows to retrieve routing data from the IPFS node. Please see https://github.com/ipfs/kubo/pull/9399 for where it is needed.