### PR TITLE
pin: follow async pinner changes: improve Pin.Verify to support kubo needs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/ipfs/interface-go-ipfs-core
 
 require (
+	github.com/Jorropo/channel v0.0.0-20230303124104-2821e25e07ff
 	github.com/gogo/protobuf v1.3.2
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipld-cbor v0.0.5
@@ -16,6 +17,8 @@ require (
 	github.com/multiformats/go-multicodec v0.6.0
 	github.com/multiformats/go-multihash v0.2.1
 )
+
+replace github.com/Jorropo/channel => github.com/MichaelMure/channel v0.0.0-20230303132646-a77d888b67d4
 
 require (
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOv
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
+github.com/MichaelMure/channel v0.0.0-20230303132646-a77d888b67d4 h1:sdBlAQ0I35hcQ8eqA5O48wNoJ7e99z4DSTrc5PDrSRI=
+github.com/MichaelMure/channel v0.0.0-20230303132646-a77d888b67d4/go.mod h1:mI95Zfa5HM2woyGuaxl2tTnfZKKzPAyjwcbvmMk7hwI=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/pin.go
+++ b/pin.go
@@ -3,6 +3,9 @@ package iface
 import (
 	"context"
 
+	"github.com/Jorropo/channel"
+	"github.com/ipfs/go-cid"
+
 	path "github.com/ipfs/interface-go-ipfs-core/path"
 
 	"github.com/ipfs/interface-go-ipfs-core/options"
@@ -22,6 +25,9 @@ type Pin interface {
 
 // PinStatus holds information about pin health
 type PinStatus interface {
+	// Cid returns the root Cid of the pin
+	Cid() cid.Cid
+
 	// Ok indicates whether the pin has been verified to be correct
 	Ok() bool
 
@@ -45,7 +51,7 @@ type PinAPI interface {
 	Add(context.Context, path.Path, ...options.PinAddOption) error
 
 	// Ls returns list of pinned objects on this node
-	Ls(context.Context, ...options.PinLsOption) (<-chan Pin, error)
+	Ls(context.Context, ...options.PinLsOption) channel.ReadOnly[Pin]
 
 	// IsPinned returns whether or not the given cid is pinned
 	// and an explanation of why its pinned
@@ -59,5 +65,5 @@ type PinAPI interface {
 	Update(ctx context.Context, from path.Path, to path.Path, opts ...options.PinUpdateOption) error
 
 	// Verify verifies the integrity of pinned objects
-	Verify(context.Context) (<-chan PinStatus, error)
+	Verify(ctx context.Context, opts ...options.PinVerifyOption) channel.ReadOnly[PinStatus]
 }

--- a/tests/block.go
+++ b/tests/block.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	ipld "github.com/ipfs/go-ipld-format"
+
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	opt "github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/ipfs/interface-go-ipfs-core/path"
@@ -324,7 +325,7 @@ func (tp *TestSuite) TestBlockPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pins, err := api.Pin().Ls(ctx); err != nil || len(pins) != 0 {
+	if pins := api.Pin().Ls(ctx); pins.Err() != nil || pins.Len() != 0 {
 		t.Fatal("expected 0 pins")
 	}
 
@@ -338,7 +339,7 @@ func (tp *TestSuite) TestBlockPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pins, err := accPins(api.Pin().Ls(ctx))
+	pins, err := api.Pin().Ls(ctx).Rest()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/unixfs.go
+++ b/tests/unixfs.go
@@ -213,7 +213,7 @@ func (tp *TestSuite) TestAdd(t *testing.T) {
 			path: "/ipfs/bafkqaaa",
 			opts: []options.UnixfsAddOption{options.Unixfs.InlineLimit(0), options.Unixfs.Inline(true), options.Unixfs.RawLeaves(true)},
 		},
-		{ //TODO: after coreapi add is used in `ipfs add`, consider making this default for inline
+		{ // TODO: after coreapi add is used in `ipfs add`, consider making this default for inline
 			name: "addInlineRaw",
 			data: strFile(helloStr),
 			path: "/ipfs/bafkqadlimvwgy3zmeb3w64tmmqqq",
@@ -543,7 +543,7 @@ func (tp *TestSuite) TestAddPinned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pins, err := accPins(api.Pin().Ls(ctx))
+	pins, err := api.Pin().Ls(ctx).Rest()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Original changes: https://github.com/ipfs/go-ipfs-pinner/pull/24

Also, improve Pin.Verify so that kubo can use the CoreApi for `pin/verify` instead of re-implementing it.